### PR TITLE
Restructure the main.js layout

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,25 +1,67 @@
-// Some Example ThreeJS
-const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );
+/**
+ * ThreeJS Particle System
+ * 
+ * This file contains all the interaction with ThreeJS
+ */
+let camera, scene, renderer, clock, cube;
 
-const renderer = new THREE.WebGLRenderer();
-renderer.setSize( window.innerWidth, window.innerHeight );
-document.body.appendChild( renderer.domElement );
+init();
+animate();
 
-const geometry = new THREE.BoxGeometry();
-const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
-const cube = new THREE.Mesh( geometry, material );
-scene.add( cube );
+function init() {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 1000 );
 
-camera.position.z = 5;
 
+    clock = new THREE.Clock(true); // Will autostart
+
+    renderer = new THREE.WebGLRenderer();
+    renderer.setSize( window.innerWidth, window.innerHeight );
+    document.body.appendChild( renderer.domElement );
+
+    const geometry = new THREE.SphereGeometry();
+    const material = new THREE.MeshBasicMaterial( { color: 0xffffff } );
+    cube = new THREE.Mesh( geometry, material );
+    scene.add( cube );
+
+    camera.position.z = 5;
+    cube.position.z = -5;
+
+    window.addEventListener( 'resize', onWindowResize );
+}
+
+/**
+ *  animate() - Calls each individual animation frame and renders it.
+ */
 function animate() {
     requestAnimationFrame( animate );
 
-    cube.rotation.x += 0.01;
-    cube.rotation.y += 0.01;
+    render();
 
     renderer.render( scene, camera );
-};
+}
 
-animate();
+/**
+ * render() - Manipulates the scene property for the current render frame
+ */
+function render() {
+    cube.position.y = Math.cos(1 + clock.getElapsedTime());
+    cube.position.x = Math.sin(1 + clock.getElapsedTime());
+
+
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+}
+
+/**
+ * onWindowResize() - Called when the window is resized
+ */
+function onWindowResize() {
+    windowHalfX = window.innerWidth / 2;
+    windowHalfY = window.innerHeight / 2;
+
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+
+    renderer.setSize( window.innerWidth, window.innerHeight );
+}


### PR DESCRIPTION
The current main.js layout does not match the typical standards of three.js

Lets reorganized the structure into three methods:
- init() : set up the initial structure of the scene and meta state of the renderer
- animate() : get the current animation frame and call render()
- render() : manipulate the scene for the current render frame